### PR TITLE
Update in setup to avoid the error of flat-layout

### DIFF
--- a/mars-explorer/setup.py
+++ b/mars-explorer/setup.py
@@ -10,5 +10,6 @@ setup(
         'numpy>=1.19.2',
         'pygame>=2.0.0'
     ],
-    include_package_data=True
+    include_package_data=True,
+    py_modules=[]
 )


### PR DESCRIPTION
"error: Multiple top-level packages discovered in a flat-layout" was encountered while installing package in a virtual environment. The change in setup.py has helped to install without any error in the virtual environment. 